### PR TITLE
Add column for missing I/O wait stat

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ A more civilized iostat, with 100x more precision, and exportable to CSV format.
 
 ```
 $ cstat
-elapsed	busy%	sys%	user%	nice%	idle%
-1	2.707	1.140	1.567	0.000	97.293
-2	1.702	0.567	1.135	0.000	98.298
-3	1.994	0.997	0.997	0.000	98.006
-4	1.569	0.571	0.999	0.000	98.431
-5	6.695	1.994	4.701	0.000	93.305
-6	6.553	2.707	3.846	0.000	93.447
+elapsed	busy%	sys%	user%	nice%	idle%	wait%
+1	2.707	1.140	1.567	0.000	97.293	0.000
+2	1.702	0.567	1.135	0.000	98.298	0.133
+3	1.994	0.997	0.997	0.000	98.006	0.000
+4	1.569	0.571	0.999	0.000	98.431	0.000
+5	6.695	1.994	4.701	0.000	93.305	0.000
+6	6.553	2.707	3.846	0.000	93.447	0.000
 ```
 
 Just show the busy column, polling every 5 seconds for up to 5 minutes:

--- a/cmd/cstat/cstat.go
+++ b/cmd/cstat/cstat.go
@@ -60,7 +60,7 @@ func main() {
 
 func header() {
 	if *showHeader {
-		fmt.Printf("elapsed\tbusy%%\tsys%%\tuser%%\tnice%%\tidle%%\n")
+		fmt.Printf("elapsed\tbusy%%\tsys%%\tuser%%\tnice%%\tidle%%\twait%%\n")
 	}
 }
 
@@ -74,13 +74,14 @@ func display(psta []cpu.TimesStat, sta []cpu.TimesStat, start time.Time, last ti
 	if *justBusy {
 		fmt.Printf("%.3f\n", float64(busy)/float64(total)*100)
 	} else {
-		fmt.Printf("%d\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\n",
+		fmt.Printf("%d\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\n",
 			int64(last.Sub(start).Milliseconds())/1000,
 			float64(busy)/float64(total)*100,
 			float64(st.System-pst.System)/float64(total)*100,
 			float64(st.User-pst.User)/float64(total)*100,
 			float64(st.Nice-pst.Nice)/float64(total)*100,
 			float64(st.Idle-pst.Idle)/float64(total)*100,
+			float64(st.Iowait-pst.Iowait)/float64(total)*100,
 		)
 	}
 }


### PR DESCRIPTION
I thought "wait%" looked better than "iowait%" in the output