### PR TITLE
Add matching mstat utility for memory and swap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,12 @@
 
 GO = go
 
-all: cstat cstat-to-csv
+all: cstat cstat-to-csv mstat
 
 cstat: ./cmd/cstat/cstat.go
+	$(GO) build -o $@ $^
+
+mstat: ./cmd/mstat/mstat.go
 	$(GO) build -o $@ $^
 
 cstat-to-csv: ./cmd/cstat-to-csv/cstat-to-csv.go

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ elapsed	busy%	sys%	user%	nice%	idle%
 6	6.553	2.707	3.846	0.000	93.447
 ```
 
+Compare: `vmstat 1`
+
 Just show the busy column, polling every 5 seconds for up to 5 minutes:
 
 ```
@@ -23,3 +25,14 @@ $ cstat --poll 5s --for 5m --busy --header=false
 8.460
 ```
 
+Can also show the memory usage, optionally include swap memory with --swap option.
+
+```
+$ mstat
+elapsed	total	used	free	shared	buffers	cached	available
+1	32764724	4920732	4303108	175828	6925284	16615600	27238244
+2	32764724	4920984	4302856	175828	6925292	16615592	27237992
+3	32764724	4921476	4302352	175828	6925292	16615604	27237492
+```
+
+Compare: `free -k`

--- a/cmd/mstat/mstat.go
+++ b/cmd/mstat/mstat.go
@@ -1,0 +1,98 @@
+// mstat records Memory(+ Swap) usage. Similar to vmstat, but with more information.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/shirou/gopsutil/mem"
+)
+
+var duration = flag.Duration("for", 365*24*time.Hour, "How long to poll until exiting")
+var poll = flag.Duration("poll", 1*time.Second, "How often to poll")
+var showHeader = flag.Bool("header", true, "show header")
+var justUsed = flag.Bool("used", false, "just show used")
+var showSwap = flag.Bool("swap", false, "include swap")
+
+func main() {
+	flag.Parse()
+
+	header()
+	start := time.Now()
+	lastSample := start
+
+	sigs := make(chan os.Signal, 1)
+	done := make(chan bool, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		<-sigs
+		os.Exit(0)
+		done <- true
+	}()
+
+	for {
+		if time.Since(start) > *duration {
+			os.Exit(0)
+		}
+		time.Sleep(*poll)
+
+		st, err := mem.VirtualMemory()
+		if err != nil {
+			panic(err)
+		}
+		lastSample = time.Now()
+		displayMem(st, start, lastSample)
+		if *showSwap {
+			sst, err := mem.SwapMemory()
+			if err != nil {
+				panic(err)
+			}
+			displaySwap(sst, start, lastSample)
+		}
+	}
+}
+
+func header() {
+	if *showHeader {
+		fmt.Printf("elapsed\ttotal\tused\tfree\tshared\tbuffers\tcached\tavailable\n")
+	}
+}
+
+func displayMem(st *mem.VirtualMemoryStat, start time.Time, last time.Time) {
+	unit := 1024.0
+
+	if *justUsed {
+		fmt.Printf("%.3f\n", st.UsedPercent)
+	} else {
+		fmt.Printf("%d\t%.0f\t%.0f\t%.0f\t%.0f\t%.0f\t%.0f\t%.0f\n",
+			int64(last.Sub(start).Milliseconds())/1000,
+			float64(st.Total)/unit,
+			float64(st.Used)/unit,
+			float64(st.Free)/unit, // Linux specific
+			float64(st.Shared)/unit, // Linux specific
+			float64(st.Buffers)/unit, // Linux specific
+			float64(st.Cached)/unit, // Linux specific
+			float64(st.Available)/unit,
+		)
+	}
+}
+
+func displaySwap(st *mem.SwapMemoryStat, start time.Time, last time.Time) {
+	unit := 1024.0
+
+	if *justUsed {
+		fmt.Printf("%.3f\n", st.UsedPercent)
+	} else {
+		fmt.Printf("%d\t%.0f\t%.0f\t%.0f\n",
+			int64(last.Sub(start).Milliseconds())/1000,
+			float64(st.Total)/unit,
+			float64(st.Used)/unit,
+			float64(st.Free)/unit,
+		)
+	}
+}


### PR DESCRIPTION
Similar to cstat (and dstat), but for memory and swap

Usually you want "available", and not the historic "free"...

`/proc/meminfo`

             MemTotal %lu
                     Total usable RAM (i.e., physical RAM minus a few reserved bits and the kernel binary code).

             MemFree %lu
                     The sum of LowFree+HighFree.

             MemAvailable %lu (since Linux 3.14)
                     An estimate of how much memory is available for starting new applications, without swapping.

But the existing names are shown by `free` and `top`.